### PR TITLE
dump on unloading component

### DIFF
--- a/include/glim_ros/glim_ros.hpp
+++ b/include/glim_ros/glim_ros.hpp
@@ -49,6 +49,7 @@ private:
   double imu_time_offset;
   double points_time_offset;
   double acc_scale;
+  bool dump_on_unload;
 
   // Extension modulles
   std::vector<std::shared_ptr<ExtensionModule>> extension_modules;

--- a/src/glim_ros/glim_ros.cpp
+++ b/src/glim_ros/glim_ros.cpp
@@ -54,6 +54,14 @@ GlimROS::GlimROS(const rclcpp::NodeOptions& options) : Node("glim_ros", options)
     logger->set_level(spdlog::level::trace);
   }
 
+  dump_on_unload = false;
+  this->declare_parameter<bool>("dump_on_unload", false);
+  this->get_parameter<bool>("dump_on_unload", dump_on_unload);
+
+  if (dump_on_unload) {
+    spdlog::info("dump_on_unload={}", dump_on_unload);
+  }
+
   std::string config_path;
   this->declare_parameter<std::string>("config_path", "config");
   this->get_parameter<std::string>("config_path", config_path);
@@ -184,6 +192,12 @@ GlimROS::GlimROS(const rclcpp::NodeOptions& options) : Node("glim_ros", options)
 GlimROS::~GlimROS() {
   spdlog::debug("quit");
   extension_modules.clear();
+
+  if (dump_on_unload) {
+    std::string dump_path = "/tmp/dump";
+    wait(true);
+    save(dump_path);
+  }
 }
 
 const std::vector<std::shared_ptr<GenericTopicSubscription>>& GlimROS::extension_subscriptions() {

--- a/src/glim_rosbag.cpp
+++ b/src/glim_rosbag.cpp
@@ -163,10 +163,10 @@ int main(int argc, char** argv) {
     rclcpp::Serialization<sensor_msgs::msg::CompressedImage> compressed_image_serialization;
 
     while (reader.has_next()) {
-      rclcpp::spin_some(glim);
       if (!rclcpp::ok()) {
         return false;
       }
+      rclcpp::spin_some(glim);
 
       const auto msg = reader.read_next();
       const std::string topic_type = topic_type_map[msg->topic_name];


### PR DESCRIPTION
- Fix the bug that prevents saving the result when `glim_rosbag` is terminated in a middle of a rosbag.
- Add a rosparam to automatically save the mapping result on unloading of the component.