### PR TITLE
Add build option to allow building glim_ros2 without cv_bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,17 @@ endif()
 
 option(BUILD_WITH_CUDA "Build with GPU support" ON)
 option(BUILD_WITH_VIEWER "Build with visualizer" ON)
+option(BUILD_WITH_CV_BRIDGE "Build with cv_bridge which enables support for processing of camera images" ON)
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 find_package(glim REQUIRED)
 find_package(Boost REQUIRED COMPONENTS program_options)
+
+if(BUILD_WITH_CV_BRIDGE)
+  add_definitions(-DBUILD_WITH_CV_BRIDGE)
+endif()
 
 if(BUILD_WITH_CUDA)
   add_definitions(-DBUILD_GTSAM_POINTS_GPU)

--- a/include/glim_ros/glim_ros.hpp
+++ b/include/glim_ros/glim_ros.hpp
@@ -5,10 +5,12 @@
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 
-#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/imu.hpp>
-#include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#ifdef BUILD_WITH_CV_BRIDGE
+#include <image_transport/image_transport.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#endif
 
 namespace glim {
 class TimeKeeper;
@@ -29,7 +31,9 @@ public:
   void timer_callback();
 
   void imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg);
+#ifdef BUILD_WITH_CV_BRIDGE
   void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg);
+#endif
   size_t points_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
 
   void wait(bool auto_quit = false);
@@ -59,7 +63,9 @@ private:
   rclcpp::TimerBase::SharedPtr timer;
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub;
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr points_sub;
+#ifdef BUILD_WITH_CV_BRIDGE
   image_transport::Subscriber image_sub;
+#endif
 };
 
 }  // namespace glim

--- a/include/glim_ros/ros_compatibility.hpp
+++ b/include/glim_ros/ros_compatibility.hpp
@@ -2,6 +2,7 @@
 
 #include <functional>
 
+#ifdef BUILD_WITH_CV_BRIDGE
 #ifdef CV_BRIDGE_INCLUDE_H
 // For ROS2 humble or earlier
 #include <cv_bridge/cv_bridge.h>
@@ -10,6 +11,7 @@
 #include <cv_bridge/cv_bridge.hpp>
 #else
 #error File extension of cv_bridge is unknown!!
+#endif
 #endif
 
 // For ROS2 humble or earlier

--- a/src/glim_ros/glim_ros.cpp
+++ b/src/glim_ros/glim_ros.cpp
@@ -176,7 +176,9 @@ GlimROS::GlimROS(const rclcpp::NodeOptions& options) : Node("glim_ros", options)
   imu_qos.get_rmw_qos_profile().depth = 1000;
   imu_sub = this->create_subscription<sensor_msgs::msg::Imu>(imu_topic, imu_qos, std::bind(&GlimROS::imu_callback, this, _1));
   points_sub = this->create_subscription<sensor_msgs::msg::PointCloud2>(points_topic, rclcpp::SensorDataQoS(), std::bind(&GlimROS::points_callback, this, _1));
+  #ifdef BUILD_WITH_CV_BRIDGE
   image_sub = image_transport::create_subscription(this, image_topic, std::bind(&GlimROS::image_callback, this, _1), "raw", rmw_qos_profile_sensor_data);
+#endif
 
   for (const auto& sub : this->extension_subscriptions()) {
     spdlog::debug("subscribe to {}", sub->topic);
@@ -225,6 +227,7 @@ void GlimROS::imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg) {
   }
 }
 
+#ifdef BUILD_WITH_CV_BRIDGE
 void GlimROS::image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg) {
   spdlog::trace("image: {}.{}", msg->header.stamp.sec, msg->header.stamp.nanosec);
 
@@ -239,6 +242,7 @@ void GlimROS::image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg) 
     global_mapping->insert_image(stamp, cv_image->image);
   }
 }
+#endif
 
 size_t GlimROS::points_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg) {
   spdlog::trace("points: {}.{}", msg->header.stamp.sec, msg->header.stamp.nanosec);

--- a/src/glim_rosbag.cpp
+++ b/src/glim_rosbag.cpp
@@ -159,8 +159,10 @@ int main(int argc, char** argv) {
 
     rclcpp::Serialization<sensor_msgs::msg::Imu> imu_serialization;
     rclcpp::Serialization<sensor_msgs::msg::PointCloud2> points_serialization;
+#ifdef BUILD_WITH_CV_BRIDGE
     rclcpp::Serialization<sensor_msgs::msg::Image> image_serialization;
     rclcpp::Serialization<sensor_msgs::msg::CompressedImage> compressed_image_serialization;
+#endif
 
     while (reader.has_next()) {
       if (!rclcpp::ok()) {
@@ -237,7 +239,9 @@ int main(int argc, char** argv) {
           spdlog::debug("throttling: {} msec (workload={})", sleep_msec, workload);
           std::this_thread::sleep_for(std::chrono::milliseconds(sleep_msec));
         }
-      } else if (msg->topic_name == image_topic) {
+      }
+#ifdef BUILD_WITH_CV_BRIDGE
+      else if (msg->topic_name == image_topic) {
         if (topic_type == "sensor_msgs/msg/Image") {
           auto image_msg = std::make_shared<sensor_msgs::msg::Image>();
           image_serialization.deserialize_message(&serialized_msg, image_msg.get());
@@ -254,6 +258,7 @@ int main(int argc, char** argv) {
           return false;
         }
       }
+#endif
 
       auto found = subscription_map.find(msg->topic_name);
       if (found != subscription_map.end()) {


### PR DESCRIPTION
Currently, glim_ros2 has a hard dependency on `cv_bridge` which in turns brings the depedency on `libopencv-dev`, which is a meta package containing all OpenCV components.

However, there're situations where the hardware setup of the SLAM system does not contain any camera. glim_ros2 does not need to be built with camera image processing in such situations. This is problematic especially for Docker users, as the build time and the image size will be drastically increased.

This PR adds a new CMake build option `BUILD_WITH_CV_BRIDGE` which allows the user configure whether to build glim_ros2 with `cv_bridge`. The default value is `ON`. By setting this option to `OFF`, glim_ros2 will be built without the dependencies on `cv_bridge` and `libopencv-dev`.

Please note that this option does not complete eliminate the depedency on OpenCV. `libopencv-core` (and `libopencv-core-dev` for building) is still needed because GLIM uses `cv::Mat` for transferring camera images.