### PR TITLE
Disable BUILD_WITH_CV_BRIDGE if glim is not built with OpenCV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ ament_auto_find_build_dependencies()
 find_package(glim REQUIRED)
 find_package(Boost REQUIRED COMPONENTS program_options)
 
+if(DEFINED GLIM_USE_OPENCV AND NOT GLIM_USE_OPENCV AND BUILD_WITH_CV_BRIDGE)
+  message(WARNING "BUILD_WITH_CV_BRIDGE is disabled because glim is not built with OpenCV.")
+  set(BUILD_WITH_CV_BRIDGE OFF CACHE BOOL "glim is not built with OpenCV" FORCE)
+endif()
+
 if(BUILD_WITH_CV_BRIDGE)
   add_definitions(-DBUILD_WITH_CV_BRIDGE)
 endif()


### PR DESCRIPTION
This PR updates `CMakeLists.txt` to make use of `GLIM_USE_OPENCV` variable to check whether glim is built with OpenCV. If not, `BUILD_WITH_CV_BRIDGE` is disabled forcibly as the build will fail anyway.