### PR TITLE
Add support for changing QoS settings for subscriptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 ### glim_ros ###
 ament_auto_add_library(glim_ros SHARED
   src/glim_ros/glim_ros.cpp
+  src/glim_ros/ros_qos.cpp
 )
 target_include_directories(glim_ros PUBLIC
   include

--- a/include/glim_ros/ros_qos.hpp
+++ b/include/glim_ros/ros_qos.hpp
@@ -8,6 +8,7 @@ namespace glim {
      * @param config_ros Config instance to read QoS settings from.
      * @param module_name Module name.
      * @param parameter_name Name of QoS parameter.
+     * @param default_qos Default QoS settings to be returned when QoS is not configured.
      */
-    rclcpp::QoS get_qos_settings(const Config& config_ros, const std::string& module_name, const std::string& param_name);
+    rclcpp::QoS get_qos_settings(const Config& config_ros, const std::string& module_name, const std::string& param_name, const std::optional<rclcpp::QoS>& default_qos = {});
 }

--- a/include/glim_ros/ros_qos.hpp
+++ b/include/glim_ros/ros_qos.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <glim/util/config.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace glim {
+    /**
+     * @brief Get QoS settings from configuration file.
+     * @param config_ros Config instance to read QoS settings from.
+     * @param module_name Module name.
+     * @param parameter_name Name of QoS parameter.
+     */
+    rclcpp::QoS get_qos_settings(const Config& config_ros, const std::string& module_name, const std::string& param_name);
+}

--- a/src/glim_ros/glim_ros.cpp
+++ b/src/glim_ros/glim_ros.cpp
@@ -173,7 +173,9 @@ GlimROS::GlimROS(const rclcpp::NodeOptions& options) : Node("glim_ros", options)
   const std::string image_topic = config_ros.param<std::string>("glim_ros", "image_topic", "");
 
   // Subscribers
-  auto qos = get_qos_settings(config_ros, "glim_ros", "imu_qos");
+  rclcpp::SensorDataQoS default_imu_qos;
+  default_imu_qos.get_rmw_qos_profile().depth = 1000;
+  auto qos = get_qos_settings(config_ros, "glim_ros", "imu_qos", default_imu_qos);
   imu_sub = this->create_subscription<sensor_msgs::msg::Imu>(imu_topic, qos, std::bind(&GlimROS::imu_callback, this, _1));
 
   qos = get_qos_settings(config_ros, "glim_ros", "points_qos");

--- a/src/glim_ros/glim_ros.cpp
+++ b/src/glim_ros/glim_ros.cpp
@@ -37,6 +37,9 @@
 
 namespace glim {
 
+static bool init_qos_profile(const std::string& name, rmw_qos_profile_t& profile);
+static void get_qos(std::shared_ptr<spdlog::logger> logger, const Config& config_ros, const std::string& module_name, rclcpp::QoS& profile);
+
 GlimROS::GlimROS(const rclcpp::NodeOptions& options) : Node("glim_ros", options) {
   // Setup logger
   auto logger = spdlog::stdout_color_mt("glim");
@@ -172,12 +175,16 @@ GlimROS::GlimROS(const rclcpp::NodeOptions& options) : Node("glim_ros", options)
   const std::string image_topic = config_ros.param<std::string>("glim_ros", "image_topic", "");
 
   // Subscribers
-  auto imu_qos = rclcpp::SensorDataQoS();
-  imu_qos.get_rmw_qos_profile().depth = 1000;
-  imu_sub = this->create_subscription<sensor_msgs::msg::Imu>(imu_topic, imu_qos, std::bind(&GlimROS::imu_callback, this, _1));
-  points_sub = this->create_subscription<sensor_msgs::msg::PointCloud2>(points_topic, rclcpp::SensorDataQoS(), std::bind(&GlimROS::points_callback, this, _1));
+  rclcpp::QoS qos{0};
+
+  get_qos(logger, config_ros, "imu_qos", qos);
+  imu_sub = this->create_subscription<sensor_msgs::msg::Imu>(imu_topic, qos, std::bind(&GlimROS::imu_callback, this, _1));
+
+  get_qos(logger, config_ros, "points_qos", qos);
+  points_sub = this->create_subscription<sensor_msgs::msg::PointCloud2>(points_topic, qos, std::bind(&GlimROS::points_callback, this, _1));
 #ifdef BUILD_WITH_CV_BRIDGE
-  image_sub = image_transport::create_subscription(this, image_topic, std::bind(&GlimROS::image_callback, this, _1), "raw", rmw_qos_profile_sensor_data);
+  get_qos(logger, config_ros, "image_qos", qos);
+  image_sub = image_transport::create_subscription(this, image_topic, std::bind(&GlimROS::image_callback, this, _1), "raw", qos.get_rmw_qos_profile());
 #endif
 
   for (const auto& sub : this->extension_subscriptions()) {
@@ -348,6 +355,84 @@ void GlimROS::save(const std::string& path) {
   }
 }
 
+bool init_qos_profile(const std::string& name, rmw_qos_profile_t& profile) {
+  bool found = true;
+  if (name == "default") {
+    profile = rmw_qos_profile_default;
+  } else if (name == "system_default") {
+    profile = rmw_qos_profile_system_default;
+  } else if (name == "sensor_data") {
+    profile = rmw_qos_profile_sensor_data;
+  } else if (name == "services_default") {
+    profile = rmw_qos_profile_services_default;
+  } else if (name == "parameters") {
+    profile = rmw_qos_profile_parameters;
+  } else if (name == "parameter_events") {
+    profile = rmw_qos_profile_parameter_events;
+  } else {
+    profile = rmw_qos_profile_default;
+    found = false;
+  }
+  return found;
+}
+
+void get_qos(std::shared_ptr<spdlog::logger> logger, const Config& config_ros, const std::string& module_name, rclcpp::QoS& qos) {
+  std::vector<std::string> module_path;
+  module_path.push_back("glim_ros");
+  module_path.push_back(module_name);
+
+  rmw_qos_profile_t profile;
+  auto profile_name = config_ros.param_nested<std::string>(module_path, "profile", "sensor_data");
+  if (!init_qos_profile(profile_name, profile)) {
+    logger->warn("unknown QoS profile '{}', falling back to 'default'.", profile_name);
+  }
+
+  auto depth = config_ros.param_nested<int>(module_path, "depth");
+  if (depth.has_value()) {
+    profile.depth = depth.value();
+  }
+
+  auto str = config_ros.param_nested<std::string>(module_path, "durability");
+  if (str.has_value()) {
+    auto value = rmw_qos_durability_policy_from_str(str.value().c_str());
+    if (value == RMW_QOS_POLICY_DURABILITY_UNKNOWN) {
+      logger->warn("ignoring unknown durability policy '{}'.", str.value());
+    } else {
+      profile.durability = value;
+    }
+  }
+
+  str = config_ros.param_nested<std::string>(module_path, "reliability");
+  if (str.has_value()) {
+    auto value = rmw_qos_reliability_policy_from_str(str.value().c_str());
+    if (value == RMW_QOS_POLICY_RELIABILITY_UNKNOWN) {
+      logger->warn("ignoring unknown reliability policy '{}'.", str.value());
+    } else {
+      profile.reliability = value;
+    }
+  }
+
+  str = config_ros.param_nested<std::string>(module_path, "history");
+  if (str.has_value()) {
+    auto value = rmw_qos_history_policy_from_str(str.value().c_str());
+    if (value == RMW_QOS_POLICY_HISTORY_UNKNOWN) {
+      logger->warn("ignoring unknown history policy '{}'.", str.value());
+    } else {
+      profile.history = value;
+    }
+  }
+
+  qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(profile), profile);
+
+  logger->trace(
+    "{}: profile={}, depth={}, history={}, reliability={}, durability={}",
+    module_name,
+    profile_name,
+    qos.depth(),
+    rmw_qos_history_policy_to_str(qos.get_rmw_qos_profile().history),
+    rmw_qos_reliability_policy_to_str(qos.get_rmw_qos_profile().reliability),
+    rmw_qos_durability_policy_to_str(qos.get_rmw_qos_profile().durability));
+}
 }  // namespace glim
 
 RCLCPP_COMPONENTS_REGISTER_NODE(glim::GlimROS);

--- a/src/glim_ros/ros_qos.cpp
+++ b/src/glim_ros/ros_qos.cpp
@@ -87,16 +87,12 @@ static bool get_qos(const Config& config_ros, const std::string& module_name, co
   return is_configured;
 }
 
-rclcpp::QoS get_qos_settings(const Config& config_ros, const std::string& module_name, const std::string& param_name) {
+rclcpp::QoS get_qos_settings(const Config& config_ros, const std::string& module_name, const std::string& param_name, const std::optional<rclcpp::QoS>& default_qos) {
   std::string profile_name;
   rclcpp::QoS qos{0};
 
-  // Here we ensure the following default behavior:
-  //   - imu_qos: { "profile": "sensor_data", "depth": 1000 }
-  //   - points_qos: { "profile": "sensor_data" }
-  //   - image_qos: { "profile": "sensor_data" }
-  if (!get_qos(config_ros, module_name, param_name, profile_name, qos) && param_name == "imu_qos") {
-    qos.get_rmw_qos_profile().depth = 1000;
+  if (!get_qos(config_ros, module_name, param_name, profile_name, qos) && default_qos.has_value()) {
+    qos = default_qos.value();
   }
 
   spdlog::trace(

--- a/src/glim_ros/ros_qos.cpp
+++ b/src/glim_ros/ros_qos.cpp
@@ -1,0 +1,114 @@
+#include <glim_ros/ros_qos.hpp>
+#include <spdlog/spdlog.h>
+
+namespace glim {
+
+static bool init_qos_profile(const std::string& name, rmw_qos_profile_t& profile) {
+  bool found = true;
+  if (name == "default") {
+    profile = rmw_qos_profile_default;
+  } else if (name == "system_default") {
+    profile = rmw_qos_profile_system_default;
+  } else if (name == "sensor_data") {
+    profile = rmw_qos_profile_sensor_data;
+  } else if (name == "services_default") {
+    profile = rmw_qos_profile_services_default;
+  } else if (name == "parameters") {
+    profile = rmw_qos_profile_parameters;
+  } else if (name == "parameter_events") {
+    profile = rmw_qos_profile_parameter_events;
+  } else {
+    profile = rmw_qos_profile_default;
+    found = false;
+  }
+  return found;
+}
+
+static bool get_qos(const Config& config_ros, const std::string& module_name, const std::string& param_name, std::string& profile_name, rclcpp::QoS& qos) {
+  bool is_configured = false;
+  rmw_qos_profile_t profile;
+  std::vector<std::string> module_path;
+
+  module_path.push_back(module_name);
+  module_path.push_back(param_name);
+
+  auto profile_param = config_ros.param_nested<std::string>(module_path, "profile");
+  if (profile_param.has_value()) {
+    profile_name = profile_param.value();
+    is_configured = true;
+  } else {
+    profile_name = "sensor_data";
+  }
+
+  if (!init_qos_profile(profile_name, profile)) {
+    spdlog::warn("unknown QoS profile '{}', falling back to 'default'.", profile_name);
+  }
+
+  auto depth = config_ros.param_nested<int>(module_path, "depth");
+  if (depth.has_value()) {
+    profile.depth = depth.value();
+    is_configured = true;
+  }
+
+  auto str = config_ros.param_nested<std::string>(module_path, "durability");
+  if (str.has_value()) {
+    auto value = rmw_qos_durability_policy_from_str(str.value().c_str());
+    if (value == RMW_QOS_POLICY_DURABILITY_UNKNOWN) {
+      spdlog::warn("ignoring unknown durability policy '{}'.", str.value());
+    } else {
+      profile.durability = value;
+      is_configured = true;
+    }
+  }
+
+  str = config_ros.param_nested<std::string>(module_path, "reliability");
+  if (str.has_value()) {
+    auto value = rmw_qos_reliability_policy_from_str(str.value().c_str());
+    if (value == RMW_QOS_POLICY_RELIABILITY_UNKNOWN) {
+      spdlog::warn("ignoring unknown reliability policy '{}'.", str.value());
+    } else {
+      profile.reliability = value;
+      is_configured = true;
+    }
+  }
+
+  str = config_ros.param_nested<std::string>(module_path, "history");
+  if (str.has_value()) {
+    auto value = rmw_qos_history_policy_from_str(str.value().c_str());
+    if (value == RMW_QOS_POLICY_HISTORY_UNKNOWN) {
+      spdlog::warn("ignoring unknown history policy '{}'.", str.value());
+    } else {
+      profile.history = value;
+      is_configured = true;
+    }
+  }
+
+  qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(profile), profile);
+  return is_configured;
+}
+
+rclcpp::QoS get_qos_settings(const Config& config_ros, const std::string& module_name, const std::string& param_name) {
+  std::string profile_name;
+  rclcpp::QoS qos{0};
+
+  // Here we ensure the following default behavior:
+  //   - imu_qos: { "profile": "sensor_data", "depth": 1000 }
+  //   - points_qos: { "profile": "sensor_data" }
+  //   - image_qos: { "profile": "sensor_data" }
+  if (!get_qos(config_ros, module_name, param_name, profile_name, qos) && param_name == "imu_qos") {
+    qos.get_rmw_qos_profile().depth = 1000;
+  }
+
+  spdlog::trace(
+    "{}: profile={}, depth={}, history={}, reliability={}, durability={}",
+    param_name,
+    profile_name,
+    qos.depth(),
+    rmw_qos_history_policy_to_str(qos.get_rmw_qos_profile().history),
+    rmw_qos_reliability_policy_to_str(qos.get_rmw_qos_profile().reliability),
+    rmw_qos_durability_policy_to_str(qos.get_rmw_qos_profile().durability));
+
+  return qos;
+}
+
+}  // namespace glim


### PR DESCRIPTION
This PR adds support for changing QoS settings for `imu_topic`, `points_topic` and `image_topic` subscription. I'll submit a follow up PR to add these new configurations to `config_ros.jon` for documentation purpose once this PR gets merged.

During testing, I've encountered several times that the point cloud subscription might stop delivering messages to `points_callback` under certain conditions. I found that the issue can be fixed by changing reliability policy of the subscription from `BEST_EFFORT` to `RELIABLE`. So adding this feature may help other people facing similar issues.

Configuration of QoS is added to `glim_ros` module in the following format:
```jsonc
{
    // ...
    "imu_qos": {
        "profile": "sensor_data",
        "depth": 1000
    },
    "points_qos": {
        "profile": "default"
    },
    "imu_qos": {
        "profile": "sensor_data"
    }
}
```

This allows the user to select a builtin QoS profile and override depth, history policy, reliability policy and durability policy. Default profile is `sensor_data`.

Please note that this changes the current QoS settings for `imu_topic`, which is using depth=1000 while the default depth of `sensor_data` is 5. I don't quite get the idea of setting such a large depth here and didn't find a good way to keep this behavior. Maybe configuring this in `config_ros.jon` in `glim` is enough?