### PR TITLE
feat: add save map ROS2 service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(glim_ros VERSION 1.2.1 LANGUAGES CXX)
+project(glim_ros VERSION 1.2.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(BUILD_WITH_CV_BRIDGE "Build with cv_bridge which enables support for proc
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
+find_package(rosidl_default_generators REQUIRED)  # must be explicit; not picked up by ament_auto
 
 find_package(glim REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 find_package(glim REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/SaveMap.srv"
+)
 find_package(Boost REQUIRED COMPONENTS program_options)
 
 if(DEFINED GLIM_USE_OPENCV AND NOT GLIM_USE_OPENCV AND BUILD_WITH_CV_BRIDGE)
@@ -50,6 +54,8 @@ target_link_libraries(glim_ros
   glim::glim
 )
 rclcpp_components_register_nodes(glim_ros "glim::GlimROS")
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(glim_ros "${cpp_typesupport_target}")
 
 ament_auto_add_library(rviz_viewer SHARED
   src/glim_ros/rviz_viewer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,19 +43,20 @@ else()
 endif()
 
 ### glim_ros ###
-ament_auto_add_library(glim_ros SHARED
+ament_auto_add_library(glim_ros_node SHARED
   src/glim_ros/glim_ros.cpp
   src/glim_ros/ros_qos.cpp
 )
-target_include_directories(glim_ros PUBLIC
+set_target_properties(glim_ros_node PROPERTIES OUTPUT_NAME "glim_ros")
+target_include_directories(glim_ros_node PUBLIC
   include
 )
-target_link_libraries(glim_ros
+target_link_libraries(glim_ros_node
   glim::glim
 )
-rclcpp_components_register_nodes(glim_ros "glim::GlimROS")
+rclcpp_components_register_nodes(glim_ros_node "glim::GlimROS")
 rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
-target_link_libraries(glim_ros "${cpp_typesupport_target}")
+target_link_libraries(glim_ros_node "${cpp_typesupport_target}")
 
 ament_auto_add_library(rviz_viewer SHARED
   src/glim_ros/rviz_viewer.cpp
@@ -66,7 +67,7 @@ ament_auto_add_executable(glim_rosnode
   src/glim_rosnode.cpp
 )
 target_link_libraries(glim_rosnode
-  glim_ros
+  glim_ros_node
 )
 
 ### glim_rosbag ###
@@ -74,7 +75,7 @@ ament_auto_add_executable(glim_rosbag
   src/glim_rosbag.cpp
 )
 target_link_libraries(glim_rosbag
-  glim_ros
+  glim_ros_node
 )
 
 ### validator_node ###
@@ -82,7 +83,7 @@ ament_auto_add_executable(validator_node
   src/validator_node.cpp
 )
 target_link_libraries(validator_node
-  glim_ros
+  glim_ros_node
 )
 
 if(BUILD_WITH_VIEWER)

--- a/include/glim_ros/glim_ros.hpp
+++ b/include/glim_ros/glim_ros.hpp
@@ -3,7 +3,9 @@
 #include <any>
 #include <deque>
 #include <memory>
+#include <mutex>
 #include <rclcpp/rclcpp.hpp>
+#include <glim_ros/srv/save_map.hpp>
 
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -42,6 +44,11 @@ public:
   const std::vector<std::shared_ptr<GenericTopicSubscription>>& extension_subscriptions();
 
 private:
+  void save_map_callback(
+    const std::shared_ptr<glim_ros::srv::SaveMap::Request> request,
+    std::shared_ptr<glim_ros::srv::SaveMap::Response> response);
+
+private:
   std::unique_ptr<glim::TimeKeeper> time_keeper;
   std::unique_ptr<glim::CloudPreprocessor> preprocessor;
 
@@ -54,6 +61,10 @@ private:
   double points_time_offset;
   double acc_scale;
   bool dump_on_unload;
+  std::string dump_path;
+
+  std::mutex save_mutex;
+  rclcpp::Service<glim_ros::srv::SaveMap>::SharedPtr save_map_service;
 
   std::string intensity_field, ring_field;
 

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,9 @@
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <depend>glim</depend>
   <depend>rclcpp</depend>

--- a/src/glim_ros/glim_ros.cpp
+++ b/src/glim_ros/glim_ros.cpp
@@ -200,6 +200,17 @@ GlimROS::GlimROS(const rclcpp::NodeOptions& options) : Node("glim_ros", options)
   // Start timer
   timer = this->create_wall_timer(std::chrono::milliseconds(1), [this]() { timer_callback(); });
 
+  // Declare dump_path parameter so the save_map service (and shutdown flow) can use it
+  dump_path = "/tmp/dump";
+  this->declare_parameter<std::string>("dump_path", dump_path);
+  this->get_parameter<std::string>("dump_path", dump_path);
+
+  // Save map service — allows on-demand map saving without shutting down the node
+  save_map_service = this->create_service<glim_ros::srv::SaveMap>(
+    "~/save_map",
+    std::bind(&GlimROS::save_map_callback, this, std::placeholders::_1, std::placeholders::_2));
+  spdlog::info("save_map service ready");
+
   spdlog::debug("initialized");
 }
 
@@ -208,9 +219,8 @@ GlimROS::~GlimROS() {
   extension_modules.clear();
 
   if (dump_on_unload) {
-    std::string dump_path = "/tmp/dump";
     wait(true);
-    save(dump_path);
+    save(dump_path);  // uses dump_path member (set from ROS parameter in constructor)
   }
 }
 
@@ -386,6 +396,38 @@ void GlimROS::save(const std::string& path) {
   if (global_mapping) global_mapping->save(path);
   for (auto& module : extension_modules) {
     module->at_exit(path);
+  }
+}
+
+void GlimROS::save_map_callback(
+  const std::shared_ptr<glim_ros::srv::SaveMap::Request> request,
+  std::shared_ptr<glim_ros::srv::SaveMap::Response> response) {
+  std::unique_lock<std::mutex> lock(save_mutex, std::try_to_lock);
+  if (!lock.owns_lock()) {
+    response->success = false;
+    response->message = "Save already in progress";
+    return;
+  }
+
+  if (!global_mapping) {
+    response->success = false;
+    response->message = "Global mapping is not running";
+    return;
+  }
+
+  const std::string path = request->path.empty() ? dump_path : request->path;
+
+  spdlog::warn("save_map: saving to {} — sensor data may be dropped during optimize+write", path);
+
+  try {
+    this->save(path);
+    response->success = true;
+    response->message = "Saved to " + path;
+    spdlog::info("save_map: done");
+  } catch (const std::exception& e) {
+    response->success = false;
+    response->message = std::string("Save failed: ") + e.what();
+    spdlog::error("save_map: {}", response->message);
   }
 }
 

--- a/src/glim_ros/glim_ros.cpp
+++ b/src/glim_ros/glim_ros.cpp
@@ -220,6 +220,7 @@ GlimROS::~GlimROS() {
 
   if (dump_on_unload) {
     wait(true);
+    std::lock_guard<std::mutex> lock(save_mutex);
     save(dump_path);  // uses dump_path member (set from ROS parameter in constructor)
   }
 }
@@ -415,7 +416,9 @@ void GlimROS::save_map_callback(
     return;
   }
 
-  const std::string path = request->path.empty() ? dump_path : request->path;
+  std::string default_path;
+  this->get_parameter("dump_path", default_path);
+  const std::string path = request->path.empty() ? default_path : request->path;
 
   spdlog::warn("save_map: saving to {} — sensor data may be dropped during optimize+write", path);
 

--- a/src/glim_rosbag.cpp
+++ b/src/glim_rosbag.cpp
@@ -380,8 +380,7 @@ int main(int argc, char** argv) {
   glim->get_parameter<bool>("auto_quit", auto_quit);
 
   std::string dump_path = "/tmp/dump";
-  glim->declare_parameter<std::string>("dump_path", dump_path);
-  glim->get_parameter<std::string>("dump_path", dump_path);
+  glim->get_parameter<std::string>("dump_path", dump_path);  // declared in GlimROS constructor
 
   for (const auto& bag_filename : bag_filenames) {
     if (!read_bag(bag_filename)) {

--- a/src/glim_rosnode.cpp
+++ b/src/glim_rosnode.cpp
@@ -17,8 +17,7 @@ int main(int argc, char** argv) {
   rclcpp::shutdown();
 
   std::string dump_path = "/tmp/dump";
-  glim->declare_parameter<std::string>("dump_path", dump_path);
-  glim->get_parameter<std::string>("dump_path", dump_path);
+  glim->get_parameter<std::string>("dump_path", dump_path);  // declared in GlimROS constructor
 
   glim->wait();
   glim->save(dump_path);

--- a/srv/SaveMap.srv
+++ b/srv/SaveMap.srv
@@ -1,0 +1,4 @@
+string path    # Directory to save the map dump. Empty string = use dump_path param.
+---
+bool success
+string message


### PR DESCRIPTION
Adds a simple ROS2 save map service (`SaveMap.srv`) that allows saving the ROS node's results without shutting down the node. This is something I needed, as I wanted to save intermediate steps between sequential bags during large mobile mapping runs (processing happens offline).

To use the service:
`ros2 service call /glim_ros/save_map glim_ros/srv/SaveMap "{path: '/example/path'}" `

The save blocks the ROS2 executor thread while writing. Sensor data queued during a long save may be dropped by DDS. This is expected behaviour and is logged as a warning.  This is because I only need to run it at the end of a bag after playing, and making this asynchronous would have been a significantly more complex undertaking. 

I have tested this service running this on one of the example bags on my computer using a jazzy build, and the behaviour is as expected.

